### PR TITLE
Adding support to verify that send has been called

### DIFF
--- a/src/cypress-commands.ts
+++ b/src/cypress-commands.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 import Log from "./log";
 import IServerInvoke from "./types/IServerInvoke";
+import IServerSend from "./types/IServerSend.ts";
 import {
   clearCypressSignalrMockData,
   getCypressSignalrMockData,
@@ -23,11 +24,17 @@ export function setupCypressCommands() {
 
   cypress.Commands.add("hubPublish", hubPublish);
 
-  cypress.Commands.add("hubVerifyInvokes", hubVerify);
+  cypress.Commands.add("hubVerifyInvokes", hubVerifyInvokes);
+
+  cypress.Commands.add("hubVerifySends", hubVerifySends);
 
   cypress.Commands.add("hubClear", hubClear);
 
   cypress.Commands.add("hubPrintData", hubPrintData);
+
+  cypress.Commands.add("hubMockClearInvokes", hubMockClearInvokes);
+
+  cypress.Commands.add("hubMockClearSends", hubMockClearSends);
 }
 
 export function hubMockInvoke(hubName: string, methodName: string, payload: any) {
@@ -57,7 +64,7 @@ export function hubPublish(hubName: string, messageType: string, ...payload: any
   hubConnectionMock.publish(messageType, ...payload);
 }
 
-export function hubVerify(
+export function hubVerifyInvokes(
   hubName: string,
   messageType: string,
   callback?: (invokes: IServerInvoke[]) => void
@@ -65,11 +72,26 @@ export function hubVerify(
   const hubConnectionMock = getHubConnectionMock(hubName);
   if (!hubConnectionMock) {
     Log.error(
-      `[cy.hubVerify] - HubConnectionMock not found for hub with name: ${hubName}`
+      `[cy.hubVerifyInvokes] - HubConnectionMock not found for hub with name: ${hubName}`
     );
     return;
   }
-  hubConnectionMock.verify(messageType, callback);
+  hubConnectionMock.verifyInvokes(messageType, callback);
+}
+
+export function hubVerifySends(
+  hubName: string,
+  messageType: string,
+  callback?: (invokes: IServerSend[]) => void
+) {
+  const hubConnectionMock = getHubConnectionMock(hubName);
+  if (!hubConnectionMock) {
+    Log.error(
+      `[cy.hubVerifySends] - HubConnectionMock not found for hub with name: ${hubName}`
+    );
+    return;
+  }
+  hubConnectionMock.verifySends(messageType, callback);
 }
 
 export function hubPrintData() {
@@ -81,4 +103,30 @@ export function hubPrintData() {
 
 export function hubClear() {
   clearCypressSignalrMockData();
+}
+
+
+export function hubMockClearInvokes(hubName: string, methodName?: string) {
+  const hubConnectionMock = getHubConnectionMock(hubName);
+  if (!hubConnectionMock) {
+    Log.error(
+      `[cy.hubMockClearInvokes] - HubConnectionMock not found for hub with name: ${hubName}`
+    );
+    return;
+  }
+
+  hubConnectionMock.clearInvokes(methodName);
+}
+
+
+export function hubMockClearSends(hubName: string, methodName?: string) {
+  const hubConnectionMock = getHubConnectionMock(hubName);
+  if (!hubConnectionMock) {
+    Log.error(
+      `[cy.hubMockClearSends] - HubConnectionMock not found for hub with name: ${hubName}`
+    );
+    return;
+  }
+
+  hubConnectionMock.clearSends(methodName);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,17 @@
 /// <reference types="cypress" />
 
 import { HubConnection } from "@microsoft/signalr";
-import HubConnectionMock from "./types/HubConnectionMock";
 import { setupCypressCommands } from "./cypress-commands";
+import Log from "./log.ts";
+import HubConnectionMock from "./types/HubConnectionMock";
 import IMockData from "./types/IMockData";
 import IServerInvoke from "./types/IServerInvoke";
+import IServerSend from "./types/IServerSend.ts";
 import {
   getCypressSignalrMockData,
   isCypressRunning,
   isInVitestMode,
 } from "./utils.ts";
-import Log from "./log.ts";
 
 setupCypressCommands();
 useCypressSignalRMock("default");
@@ -70,7 +71,7 @@ declare global {
       ): Chainable<Subject>;
 
       /**
-       * Verifies that a message was sent from the Client => Server
+       * Verifies that a message was sent from the Client => Server with the invoke() method
        * @param hubName The name of the hub
        * @param messageType The name of the message type
        * @param callback A callback function that will be called with the invokes
@@ -82,6 +83,18 @@ declare global {
       ): Chainable<Subject>;
 
       /**
+       * Verifies that a message was sent from the Client => Server with the send() method
+       * @param hubName The name of the hub
+       * @param messageType The name of the message type
+       * @param callback A callback function that will be called with the invokes
+       */
+      hubVerifySends(
+        hubName: string,
+        messageType: string,
+        callback?: (invokes: IServerSend[]) => void
+      ): Chainable<Subject>;
+
+      /**
        * Clears all data from the window["cypress-signalr-mock"] object
        */
       hubClear(): Chainable<Subject>;
@@ -90,15 +103,37 @@ declare global {
        * Prints the current data to console in the window["cypress-signalr-mock"] object
        */
       hubPrintData(): Chainable<Subject>;
+
+      hubMockInvoke(hubName: string, methodName: string, payload: any): Chainable<Subject>;
+
+      hubUnmockInvoke(hubName: string, methodName: string) : Chainable<Subject>;
+
+      /**
+       * Clears all called invokes for a specific hub. If methodName is provided, only clears invokes for that method.
+       * @param hubName The name of the hub
+       * @param methodName The name of the message method to clear (optional)
+       */
+      hubMockClearInvokes(hubName: string, methodName?: string): Chainable<Subject>;
+
+      /**
+       * Clears all called sends for a specific hub. If methodName is provided, only clears sends for that method.
+       * @param hubName The name of the hub
+       * @param methodName The name of the message method to clear (optional)
+       */
+      hubMockClearSends(hubName: string, methodName?: string): Chainable<Subject>;
     }
   }
 }
 
 export {
+  hubClear,
+  hubMockClearInvokes,
+  hubMockClearSends,
   hubMockInvoke,
+  hubPrintData,
   hubPublish,
   hubUnmockInvoke,
-  hubVerify,
-  hubClear,
-  hubPrintData,
+  hubVerifyInvokes,
+  hubVerifySends
 } from "./cypress-commands";
+

--- a/src/types/HubConnectionMock.ts
+++ b/src/types/HubConnectionMock.ts
@@ -1,9 +1,10 @@
-import Log from "../log";
-import { Subject } from "rxjs";
-import IPayload from "./IPayload";
-import { IHubConnectionData } from "./IHubConnectionData";
-import IServerInvoke from "./IServerInvoke";
 import { IStreamResult, Subject as SignalrSubject } from "@microsoft/signalr";
+import { Subject } from "rxjs";
+import Log from "../log";
+import { IHubConnectionData } from "./IHubConnectionData";
+import IPayload from "./IPayload";
+import IServerInvoke from "./IServerInvoke";
+import IServerSend from "./IServerSend";
 
 /**
  * Mock implementation of HubConnection,
@@ -12,6 +13,7 @@ import { IStreamResult, Subject as SignalrSubject } from "@microsoft/signalr";
 export default class HubConnectionMock {
   private _hubConnectionData: IHubConnectionData[] = [];
   private _serverInvokes: IServerInvoke[] = [];
+  private _serverSends: IServerSend[] = [];
   private _invokeResponses: { [key: string]: any } = {};
   public name: string;
 
@@ -37,20 +39,48 @@ export default class HubConnectionMock {
     });
   }
 
-  public verify(
+  public verifyInvokes(
     messageType: string,
     callback?: (invokes: IServerInvoke[]) => void
   ): void {
-    messageType = messageType.toLowerCase();
-
     const currentInvokes = this._serverInvokes.filter(
       (s) => s.action === messageType
-    );
+    ).sort((a, b) => a.timestamp - b.timestamp);
 
     if (callback) {
       callback(currentInvokes);
     }
   }
+
+  public verifySends(
+    messageType: string,
+    callback?: (invokes: IServerSend[]) => void
+  ): void {
+    const currentSends = this._serverSends.filter(
+      (s) => s.action === messageType
+    ).sort((a, b) => a.timestamp - b.timestamp);
+
+    if (callback) {
+      callback(currentSends);
+    }
+  }
+
+  public clearInvokes(methodName? : string): void {
+    if (methodName) {
+      this._serverInvokes = this._serverInvokes.filter(invoke => invoke.action !== methodName);
+    } else {
+      this._serverInvokes = [];
+    }
+  }
+
+  public clearSends(methodName? : string): void {
+    if (methodName) {
+      this._serverSends = this._serverSends.filter(send => send.action !== methodName);
+    } else {
+      this._serverSends = [];
+    }
+  }
+
 
   public mockInvoke(methodName: string, payload: any) {
     this._invokeResponses[methodName] = payload;
@@ -158,7 +188,8 @@ export default class HubConnectionMock {
     return new Promise<T>((resolve) => {
       this._serverInvokes.push({
         action: methodName,
-        args,
+        args: args,
+        timestamp: Date.now()
       });
       const mockedResponse = this._invokeResponses[methodName];
       if(mockedResponse !== undefined){
@@ -270,8 +301,14 @@ export default class HubConnectionMock {
    */
   // @ts-ignore
   public send(methodName: string, ...args: any[]): Promise<void> {
-    return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this._serverSends.push({
+        action: methodName,
+        args: args,
+        timestamp: Date.now()
+      });
+      resolve();
+    });
   }
-
   // endregion
 }

--- a/src/types/IServerSend.ts
+++ b/src/types/IServerSend.ts
@@ -1,4 +1,4 @@
-export default interface IServerInvoke {
+export default interface IServerSend {
   action: string;
   args: any[];
   timestamp: number;

--- a/tests/hub-mockInvoke-cypress-command.test.ts
+++ b/tests/hub-mockInvoke-cypress-command.test.ts
@@ -1,5 +1,5 @@
-import { vi, test, expect, describe } from "vitest";
-import { useCypressSignalRMock, hubMockInvoke, hubUnmockInvoke } from "../src";
+import { describe, expect, test, vi } from "vitest";
+import { hubMockClearInvokes, hubMockClearSends, hubMockInvoke, hubUnmockInvoke, hubVerifyInvokes, hubVerifySends, useCypressSignalRMock } from "../src";
 
 describe("cy.hubMockInvoke() method", () => {
   test("Should return mocked response when Invoke() is called", async () => {
@@ -7,7 +7,7 @@ describe("cy.hubMockInvoke() method", () => {
 
     const connection = useCypressSignalRMock("testHub");
     hubMockInvoke("testHub", "test", "Hello World!");
-    const invokeResult = await connection.invoke("test");
+    const invokeResult = await connection!.invoke("test");
 
     expect(invokeResult).toBe("Hello World!");
   });
@@ -19,15 +19,112 @@ describe("cy.hubUnmockInvoke() method", () => {
 
     const connection = useCypressSignalRMock("testHub2");
     hubMockInvoke("testHub2", "test", "Hello World!");
-    const invokeResult = await connection.invoke("test");
-    const invokeResult2 = await connection.invoke("test");
+    const invokeResult = await connection!.invoke("test");
+    const invokeResult2 = await connection!.invoke("test");
 
     
-    hubUnmockInvoke("testHub2", "test", "Hello World!");
-    const invokeResult3 = await connection.invoke("test");
+    hubUnmockInvoke("testHub2", "test");
+    const invokeResult3 = await connection!.invoke("test");
 
     expect(invokeResult).toBe("Hello World!");
     expect(invokeResult2).toBe("Hello World!");
     expect(invokeResult3).toBe(0);
+  });
+});
+
+
+
+describe("cy.hubVerify[Invokes/Sends]() method", () => {
+
+  test("Should verify that invoke was called with correct parameters", () => {
+    vi.stubGlobal("Cypress", {});
+    const hubName = "testHubInvokes";
+    const hubConnection = useCypressSignalRMock(hubName, {
+      enableForVitest: false,
+    });
+
+    hubConnection!.invoke("invokeMethod", 1, 2, 3);
+
+    hubVerifyInvokes(hubName, "invokeMethod", (invokes) => {
+      expect(invokes.length).toBe(1);
+      expect(invokes[0].args).toEqual([1, 2, 3]);
+    });
+
+    hubConnection!.invoke("invokeMethod2", 4, 5, 6);
+      hubVerifyInvokes(hubName, "invokeMethod2", (invokes) => {
+      expect(invokes.length).toBe(1);
+      expect(invokes[0].args).toEqual([4, 5, 6]);
+    });
+
+    hubConnection!.invoke("invokeMethod", 3, 2, 1);
+
+    hubVerifyInvokes(hubName, "invokeMethod", (invokes) => {
+      expect(invokes.length).toBe(2);
+      expect(invokes[0].args).toEqual([1, 2, 3]);
+      expect(invokes[1].args).toEqual([3, 2, 1]);
+    });
+    
+    hubMockClearInvokes(hubName, "invokeMethod");
+
+    hubVerifyInvokes(hubName, "invokeMethod", (invokes) => {
+      expect(invokes.length).toBe(0);
+    });
+
+    hubVerifyInvokes(hubName, "invokeMethod2", (invokes) => {
+      expect(invokes.length).toBe(1);
+    });
+
+    hubMockClearInvokes(hubName);
+    hubVerifyInvokes(hubName, "invokeMethod", (invokes) => {
+      expect(invokes.length).toBe(0);
+    });
+
+    hubVerifyInvokes(hubName, "invokeMethod2", (invokes) => {
+      expect(invokes.length).toBe(0);
+    });
+  });
+
+  test("Should verify that send was called with correct parameters", () => {
+    vi.stubGlobal("Cypress", {});
+    const hubName = "testHubSends";
+    const hubConnection = useCypressSignalRMock(hubName, {
+      enableForVitest: false,
+    });
+
+    hubConnection!.send("sendMethod", "Test");
+    hubVerifySends(hubName, "sendMethod", (sends) => {
+      expect(sends.length).toBe(1);
+      expect(sends[0].args).toEqual(["Test"]);
+    });
+
+    hubConnection!.send("sendMethod2", 4, 5, 6);
+      hubVerifySends(hubName, "sendMethod2", (sends) => {
+      expect(sends.length).toBe(1);
+      expect(sends[0].args).toEqual([4, 5, 6]);
+    });
+
+    hubConnection!.send("sendMethod", 3, 2, 1);
+    hubVerifySends(hubName, "sendMethod", (sends) => {
+      expect(sends.length).toBe(2);
+      expect(sends[0].args).toEqual(["Test"]);
+      expect(sends[1].args).toEqual([3, 2, 1]);
+    });
+    
+    hubMockClearSends(hubName, "sendMethod");
+    hubVerifySends(hubName, "sendMethod", (sends) => {
+      expect(sends.length).toBe(0);
+    });
+    hubVerifySends(hubName, "sendMethod2", (sends) => {
+      expect(sends.length).toBe(1);
+    });
+
+    hubMockClearSends(hubName);
+    hubVerifySends(hubName, "sendMethod", (sends) => {
+      expect(sends.length).toBe(0);
+    });
+
+    hubVerifySends(hubName, "sendMethod2", (sends) => {
+      expect(sends.length).toBe(0);
+    });
   });
 });

--- a/tests/hub-publish-vitest-command.test.ts
+++ b/tests/hub-publish-vitest-command.test.ts
@@ -1,5 +1,5 @@
-import { vi, test, expect, describe } from "vitest";
-import { useCypressSignalRMock, hubPublish } from "../src";
+import { describe, expect, test } from "vitest";
+import { hubPublish, useCypressSignalRMock } from "../src";
 
 describe("hubPublish() method", () => {
   test("Should receive all values in SignalR listener when hubPublish() is called multiple times", () => {
@@ -9,7 +9,7 @@ describe("hubPublish() method", () => {
       enableForVitest: true,
     });
 
-    connection.on("progress", (value) => {
+    connection!.on("progress", (value) => {
       publishResult.push(value);
     });
 


### PR DESCRIPTION
This PR implements the feature to verify whether send was called on a hub. The `invoke` logic was used as a basis for this. Methods were also added to delete the list of invokes and sends (`hubMockClearInvokes` and `hubMockClearSends`), which can be helpful for testing. The structure for storing `invokes` and `sends` has been slightly adjusted so that there is now a timestamp to correctly determine the call sequence and to have a time factor when testing. In addition, the arguments are now also stored as a list. A unit test has also been added to test the behavior. With this PR, I also added the `hubMockInvoke` and `hubUnmockInvoke` functions to the Cypress context so that they can also be used in the `cy.` context.